### PR TITLE
- added types_windows.go file which includes the exports for windows fun...

### DIFF
--- a/cpu.go
+++ b/cpu.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
 	"log"
 	"strconv"
 	"strings"
@@ -41,14 +40,9 @@ func (m *CPUInputModule) TearDown() error {
 	return nil
 }
 
-func (m *CPUInputModule) GetMetrics() ([]Metric, error) {
+func (m *CPUInputModule) ParseProcStat(content string) ([]Metric, error) {
 	metrics := make([]Metric, 0, 10)
 
-	b, err := ioutil.ReadFile("/proc/stat")
-	if err != nil {
-		return nil, err
-	}
-	content := string(b)
 	lines := strings.Split(content, "\n")
 
 	cpus := make(map[string][]float64)

--- a/cpu_linux.go
+++ b/cpu_linux.go
@@ -1,0 +1,19 @@
+// +build linux
+
+package main
+
+import (
+	"io/ioutil"
+	"strings"
+)
+
+func (m *CPUInputModule) GetMetrics() ([]Metric, error) {
+
+	b, err := ioutil.ReadFile("/proc/stat")
+	if err != nil {
+		return nil, err
+	}
+	content := string(b)
+
+	return m.ParseProcStat(content)
+}

--- a/cpu_windows.go
+++ b/cpu_windows.go
@@ -1,0 +1,111 @@
+// +build windows
+
+package main
+
+import (
+	"fmt"
+	"runtime"
+	"unsafe"
+)
+
+func (m *CPUInputModule) GetMetrics() ([]Metric, error) {
+
+	cpuNum := runtime.NumCPU()
+
+	var perfSize SYSTEM_PROCESSOR_PERFORMANCE_INFORMATION
+
+	performanceInformation := make([]SYSTEM_PROCESSOR_PERFORMANCE_INFORMATION, cpuNum)
+	sizeofPerformanceInformation := uint64(unsafe.Sizeof(perfSize)) * uint64(cpuNum)
+
+	r1, _, err := _ntQuerySystemInformation.Call(SystemProcessorPerformanceInformation, uintptr(unsafe.Pointer(&performanceInformation[0])), uintptr(sizeofPerformanceInformation), uintptr(0))
+
+	if !(r1 >= 0) {
+		return nil, err
+	}
+
+	var SysTime uint64
+	var userTime uint64
+	var idleTime uint64
+	var intTime uint64
+
+	var interruptCount uint32
+
+	content := string("")
+
+	for i := 0; i < cpuNum; i++ {
+		SysTime += (performanceInformation[i].KernelTime - performanceInformation[i].IdleTime) * 100 / 10000000
+		idleTime += performanceInformation[i].IdleTime * 100 / 10000000
+		userTime += performanceInformation[i].UserTime * 100 / 10000000
+		intTime += performanceInformation[i].InterruptTime * 100 / 10000000
+	}
+
+	content += fmt.Sprintf("cpu %d %d %d %d %d %d %d %d \n", userTime, 0, SysTime, idleTime, 0, intTime, 0, 0)
+
+	SysTime = 0
+	userTime = 0
+	idleTime = 0
+	intTime = 0
+
+	for i := 0; i < cpuNum; i++ {
+		interruptCount += performanceInformation[i].InterruptCount
+
+		SysTime = (performanceInformation[i].KernelTime - performanceInformation[i].IdleTime) * 100 / 10000000
+		idleTime = performanceInformation[i].IdleTime * 100 / 10000000
+		userTime = performanceInformation[i].UserTime * 100 / 10000000
+		intTime = performanceInformation[i].InterruptTime * 100 / 10000000
+
+		content += fmt.Sprintf("cpu%d %d %d %d %d %d %d %d %d \n", i, userTime, 0, SysTime, idleTime, 0, intTime, 0, 0)
+	}
+
+	//spi := new(SYSTEM_PERFORMANCE_INFORMATION)
+
+	spi := SYSTEM_PERFORMANCE_INFORMATION{}
+
+	sizeof_spi := unsafe.Sizeof(spi)
+
+	fmt.Printf("SIZE %d \n", uintptr(sizeof_spi))
+
+	r1, _, err = _ntQuerySystemInformation.Call(SystemPerformanceInformation, uintptr(unsafe.Pointer(&spi)), uintptr(sizeof_spi), uintptr(0))
+	if !(r1 >= 0) {
+
+		return nil, err
+	}
+
+	var timeSize SYSTEM_TIMEOFDAY_INFORMATION
+	sizeofTimeInformation := uint64(unsafe.Sizeof(timeSize))
+
+	r1, _, err = _ntQuerySystemInformation.Call(SystemTimeOfDayInformation, uintptr(unsafe.Pointer(&timeSize)), uintptr(sizeofTimeInformation), uintptr(0))
+
+	if !(r1 >= 0) {
+		return nil, err
+	}
+
+	var pagesIn uint32 = spi.PageReadCount
+	var pagesOut uint32 = spi.PageReadIoCount + spi.MappedWriteIoCount
+	var swapIn uint32 = spi.PageReadCount
+	var swapout uint32 = spi.PageReadIoCount
+	var contextSwitches uint32 = spi.ContextSwitches
+	var bootTime int64 = m.GetBootTime(timeSize.BootTime)
+
+	content += fmt.Sprintf("page %d %d \n", pagesIn, pagesOut)
+	content += fmt.Sprintf("swap %d %d \n", swapIn, swapout)
+	content += fmt.Sprintf("intr %d \n", interruptCount)
+	content += fmt.Sprintf("ctxt %d \n", contextSwitches)
+	content += fmt.Sprintf("btime %d \n", bootTime)
+
+	return m.ParseProcStat(content)
+}
+
+func (m *CPUInputModule) GetBootTime(inTime uint64) int64 {
+
+	x := inTime
+
+	if inTime == 0 {
+		return 0
+	}
+
+	x -= 0x19db1ded53e8000
+	x /= 10000000
+
+	return int64(x)
+}

--- a/cpu_windows.go
+++ b/cpu_windows.go
@@ -57,13 +57,9 @@ func (m *CPUInputModule) GetMetrics() ([]Metric, error) {
 		content += fmt.Sprintf("cpu%d %d %d %d %d %d %d %d %d \n", i, userTime, 0, SysTime, idleTime, 0, intTime, 0, 0)
 	}
 
-	//spi := new(SYSTEM_PERFORMANCE_INFORMATION)
-
 	spi := SYSTEM_PERFORMANCE_INFORMATION{}
 
 	sizeof_spi := unsafe.Sizeof(spi)
-
-	fmt.Printf("SIZE %d \n", uintptr(sizeof_spi))
 
 	r1, _, err = _ntQuerySystemInformation.Call(SystemPerformanceInformation, uintptr(unsafe.Pointer(&spi)), uintptr(sizeof_spi), uintptr(0))
 	if !(r1 >= 0) {

--- a/types_windows.go
+++ b/types_windows.go
@@ -21,12 +21,124 @@ type (
 		ullAvailVirtual         dwordLong
 		ullAvailExtendedVirtual dwordLong
 	}
+
+	SYSTEM_PROCESSOR_PERFORMANCE_INFORMATION struct {
+		IdleTime       uint64
+		KernelTime     uint64
+		UserTime       uint64
+		DpcTime        uint64
+		InterruptTime  uint64
+		InterruptCount uint32
+	}
+
+	SYSTEM_PERFORMANCE_INFORMATION struct {
+		IdleProcessTime          uint64
+		IoReadTransferCount      uint64
+		IoWriteTransferCount     uint64
+		IoOtherTransferCount     uint64
+		IoReadOperationCount     uint32
+		IoWriteOperationCount    uint32
+		IoOtherOperationCount    uint32
+		AvailablePages           uint32
+		CommittedPages           uint32
+		CommitLimit              uint32
+		PeakCommitment           uint32
+		PageFaultCount           uint32
+		CopyOnWriteCount         uint32
+		TransitionCount          uint32
+		CacheTransitionCount     uint32
+		DemandZeroCount          uint32
+		PageReadCount            uint32
+		PageReadIoCount          uint32
+		CacheReadCount           uint32
+		CacheIoCount             uint32
+		DirtyPagesWriteCount     uint32
+		DirtyWriteIoCount        uint32
+		MappedPagesWriteCount    uint32
+		MappedWriteIoCount       uint32
+		PagedPoolPages           uint32
+		NonPagedPoolPages        uint32
+		PagedPoolAllocs          uint32
+		PagedPoolFrees           uint32
+		NonPagedPoolAllocs       uint32
+		NonPagedPoolFrees        uint32
+		FreeSystemPtes           uint32
+		ResidentSystemCodePage   uint32
+		TotalSystemDriverPages   uint32
+		TotalSystemCodePages     uint32
+		NonPagedPoolLookasideHit uint32
+		PagedPoolLookasideHits   uint32
+		AvailablePagedPoolPages  uint32
+		ResidentSystemCachePage  uint32
+		ResidentPagedPoolPage    uint32
+		ResidentSystemDriverPage uint32
+		CcFastReadNoWait         uint32
+		CcFastReadWait           uint32
+		CcFastReadResourceMiss   uint32
+		CcFastReadNotPossible    uint32
+		CcFastMdlReadNoWait      uint32
+		CcFastMdlReadWait        uint32
+		CcFastMdlReadResourceMis uint32
+		CcFastMdlReadNotPossible uint32
+		CcMapDataNoWait          uint32
+		CcMapDataWait            uint32
+		CcMapDataNoWaitMiss      uint32
+		CcMapDataWaitMiss        uint32
+		CcPinMappedDataCount     uint32
+		CcPinReadNoWait          uint32
+		CcPinReadWait            uint32
+		CcPinReadNoWaitMiss      uint32
+		CcPinReadWaitMiss        uint32
+		CcCopyReadNoWait         uint32
+		CcCopyReadWait           uint32
+		CcCopyReadNoWaitMiss     uint32
+		CcCopyReadWaitMiss       uint32
+		CcMdlReadNoWait          uint32
+		CcMdlReadWait            uint32
+		CcMdlReadNoWaitMiss      uint32
+		CcMdlReadWaitMiss        uint32
+		CcReadAheadIos           uint32
+		CcLazyWriteIos           uint32
+		CcLazyWritePages         uint32
+		CcDataFlushes            uint32
+		CcDataPages              uint32
+		ContextSwitches          uint32
+		FirstLevelTbFills        uint32
+		SecondLevelTbFills       uint32
+		SystemCalls              uint32
+		CcTotalDirtyPages        uint64
+		CcDirtyPageThreshold     uint64
+		ResidentAvailablePages   int64
+	}
+
+	SYSTEM_TIMEOFDAY_INFORMATION struct {
+		BootTime          uint64
+		CurrentTime       uint64
+		TimeZoneBias      uint64
+		CurrentTimeZoneId uint64
+		Reserved1         uint64
+	}
+)
+
+const (
+	SystemBasicInformation                = 0
+	SystemPerformanceInformation          = 2
+	SystemTimeOfDayInformation            = 3
+	SystemProcessInformation              = 5
+	SystemProcessorPerformanceInformation = 8
+	SystemInterruptInformation            = 23
+	SystemExceptionInformation            = 33
+	SystemRegistryQuotaInformation        = 37
+	SystemLookasideInformation            = 45
+	SystemPolicyInformation               = 134
 )
 
 var kernel32 = syscall.NewLazyDLL("kernel32.dll")
+var ntDll = syscall.NewLazyDLL("Ntdll.dll")
 
 var (
-	_globalMemoryStatusEx = kernel32.NewProc("GlobalMemoryStatusEx")
-	_getDiskFreeSpaceEx   = kernel32.NewProc("GetDiskFreeSpaceExW")
-	_getLogicalDrives     = kernel32.NewProc("GetLogicalDrives")
+	_globalMemoryStatusEx     = kernel32.NewProc("GlobalMemoryStatusEx")
+	_getDiskFreeSpaceEx       = kernel32.NewProc("GetDiskFreeSpaceExW")
+	_getLogicalDrives         = kernel32.NewProc("GetLogicalDrives")
+	_ntQuerySystemInformation = ntDll.NewProc("NtQuerySystemInformation")
 )


### PR DESCRIPTION
This was a giant hack :P essentially windows simulates the /proc/stat format and both linux and windows parse the same information. There are some fields in windows that are not valid like Guest and Steal etc.. which btw those are not always around in every kernel so we should do some more rigid checking to make sure we don't run into issues with that ? 
