### PR TITLE
Refactoring how the Metric struct is used and created

### DIFF
--- a/cpu_linux.go
+++ b/cpu_linux.go
@@ -4,10 +4,9 @@ package main
 
 import (
 	"io/ioutil"
-	"strings"
 )
 
-func (m *CPUInputModule) GetMetrics() ([]Metric, error) {
+func (m *CPUInputModule) GetMetrics() (*ModuleMetrics, error) {
 
 	b, err := ioutil.ReadFile("/proc/stat")
 	if err != nil {

--- a/cpu_windows.go
+++ b/cpu_windows.go
@@ -8,7 +8,7 @@ import (
 	"unsafe"
 )
 
-func (m *CPUInputModule) GetMetrics() ([]Metric, error) {
+func (m *CPUInputModule) GetMetrics() (*ModuleMetrics, error) {
 
 	cpuNum := runtime.NumCPU()
 

--- a/diskspace_linux.go
+++ b/diskspace_linux.go
@@ -9,12 +9,10 @@ import (
 	"log"
 	"path/filepath"
 	"strings"
-	"time"
 )
 
-func (m *DiskspaceInputModule) GetMetrics() ([]Metric, error) {
+func (m *DiskspaceInputModule) GetMetrics() (*ModuleMetrics, error) {
 	metrics := make([]Metric, 0, 50)
-	now := time.Now()
 
 	filesystems, err := GetFileSystems(m)
 	if err != nil {
@@ -28,37 +26,18 @@ func (m *DiskspaceInputModule) GetMetrics() ([]Metric, error) {
 	}
 
 	for _, stat := range stats {
-		used := Metric{
-			module:    m.Name(),
-			name:      fmt.Sprintf("%s.used", stat.DeviceName),
-			value:     stat.Used,
-			timestamp: now,
-		}
-		free := Metric{
-			module:    m.Name(),
-			name:      fmt.Sprintf("%s.free", stat.DeviceName),
-			value:     stat.Free,
-			timestamp: now,
-		}
-		reserved := Metric{
-			module:    m.Name(),
-			name:      fmt.Sprintf("%s.reserved", stat.DeviceName),
-			value:     stat.Reserved,
-			timestamp: now,
-		}
-		available := Metric{
-			module:    m.Name(),
-			name:      fmt.Sprintf("%s.available", stat.DeviceName),
-			value:     stat.Available,
-			timestamp: now,
-		}
+		used := NewMetric(fmt.Sprintf("%s.used", stat.DeviceName), stat.Used)
+		free := NewMetric(fmt.Sprintf("%s.free", stat.DeviceName), stat.Free)
+		reserved := NewMetric(fmt.Sprintf("%s.reserved", stat.DeviceName), stat.Reserved)
+		available := NewMetric(fmt.Sprintf("%s.available", stat.DeviceName), stat.Available)
+
 		metrics = append(metrics, used)
 		metrics = append(metrics, free)
 		metrics = append(metrics, reserved)
 		metrics = append(metrics, available)
 	}
 
-	return metrics, nil
+	return &ModuleMetrics{Module: m.Name(), Metrics: metrics}, nil
 }
 
 func GetFileSystems(m *DiskspaceInputModule) ([]Filesystem, error) {

--- a/diskspace_windows.go
+++ b/diskspace_windows.go
@@ -6,14 +6,11 @@ import (
 	"fmt"
 	"strconv"
 	"syscall"
-	"time"
 	"unsafe"
 )
 
-func (m *DiskspaceInputModule) GetMetrics() ([]Metric, error) {
-
+func (m *DiskspaceInputModule) GetMetrics() (*ModuleMetrics, error) {
 	metrics := make([]Metric, 0, 50)
-	now := time.Now()
 
 	// we grab all the drives
 	drives := m.GetLogicalDrives()
@@ -31,30 +28,16 @@ func (m *DiskspaceInputModule) GetMetrics() ([]Metric, error) {
 
 		usedBytes := lpTotalNumberOfBytes - lpTotalNumberOfFreeBytes
 
-		used := Metric{
-			module:    m.Name(),
-			name:      fmt.Sprintf("%s.used", drive[:1]),
-			value:     float64(usedBytes),
-			timestamp: now,
-		}
-		free := Metric{
-			module:    m.Name(),
-			name:      fmt.Sprintf("%s.free", drive[:1]),
-			value:     float64(lpTotalNumberOfFreeBytes),
-			timestamp: now,
-		}
-		available := Metric{
-			module:    m.Name(),
-			name:      fmt.Sprintf("%s.available", drive[:1]),
-			value:     float64(lpFreeBytesAvailable),
-			timestamp: now,
-		}
+		used := NewMetric(fmt.Sprintf("%s.used", drive[:1]), float64(usedBytes))
+		free := NewMetric(fmt.Sprintf("%s.free", drive[:1]), float64(lpTotalNumberOfFreeBytes))
+		available := NewMetric(fmt.Sprintf("%s.available", drive[:1]), float64(lpFreeBytesAvailable))
+
 		metrics = append(metrics, used)
 		metrics = append(metrics, free)
 		metrics = append(metrics, available)
 	}
 
-	return metrics, nil
+	return &ModuleMetrics{Module: m.Name(), Metrics: metrics}, nil
 }
 
 func (m *DiskspaceInputModule) GetLogicalDrives() []string {

--- a/diskusage.go
+++ b/diskusage.go
@@ -41,7 +41,7 @@ func (m *DiskusageInputModule) TearDown() error {
 	return nil
 }
 
-func (m *DiskusageInputModule) GetMetrics() ([]Metric, error) {
+func (m *DiskusageInputModule) GetMetrics() (*ModuleMetrics, error) {
 	metrics := make([]Metric, 0, 50)
 	now := time.Now()
 	timeDiff := time.Since(m.previousTime).Seconds()
@@ -63,42 +63,12 @@ func (m *DiskusageInputModule) GetMetrics() ([]Metric, error) {
 				readBytesPerSecond := ((stats.ReadsSectors - previous.ReadsSectors) * 512) / timeDiff
 				writeBytesPerSecond := ((stats.WritesSectors - previous.WritesSectors) * 512) / timeDiff
 
-				metrics = append(metrics, Metric{
-					module:    m.Name(),
-					name:      fmt.Sprintf("%s.Reads", device),
-					value:     readsPerSecond,
-					timestamp: now,
-				})
-				metrics = append(metrics, Metric{
-					module:    m.Name(),
-					name:      fmt.Sprintf("%s.Writes", device),
-					value:     writesPerSecond,
-					timestamp: now,
-				})
-				metrics = append(metrics, Metric{
-					module:    m.Name(),
-					name:      fmt.Sprintf("%s.ReadsMerged", device),
-					value:     readsMergedPerSecond,
-					timestamp: now,
-				})
-				metrics = append(metrics, Metric{
-					module:    m.Name(),
-					name:      fmt.Sprintf("%s.WritesMerged", device),
-					value:     writesMergedPerSecond,
-					timestamp: now,
-				})
-				metrics = append(metrics, Metric{
-					module:    m.Name(),
-					name:      fmt.Sprintf("%s.ReadBytes", device),
-					value:     readBytesPerSecond,
-					timestamp: now,
-				})
-				metrics = append(metrics, Metric{
-					module:    m.Name(),
-					name:      fmt.Sprintf("%s.WriteBytes", device),
-					value:     writeBytesPerSecond,
-					timestamp: now,
-				})
+				metrics = append(metrics, NewMetric(fmt.Sprintf("%s.Reads", device), readsPerSecond))
+				metrics = append(metrics, NewMetric(fmt.Sprintf("%s.Writes", device), writesPerSecond))
+				metrics = append(metrics, NewMetric(fmt.Sprintf("%s.ReadsMerged", device), readsMergedPerSecond))
+				metrics = append(metrics, NewMetric(fmt.Sprintf("%s.WritesMerged", device), writesMergedPerSecond))
+				metrics = append(metrics, NewMetric(fmt.Sprintf("%s.ReadBytes", device), readBytesPerSecond))
+				metrics = append(metrics, NewMetric(fmt.Sprintf("%s.WriteBytes", device), writeBytesPerSecond))
 			}
 		}
 	}
@@ -106,7 +76,7 @@ func (m *DiskusageInputModule) GetMetrics() ([]Metric, error) {
 	m.previousDiskStats = allStats
 	m.previousTime = now
 
-	return metrics, nil
+	return &ModuleMetrics{Module: m.Name(), Metrics: metrics}, nil
 }
 
 func GetDiskStats(path string) (map[string]DiskStats, error) {

--- a/main.go
+++ b/main.go
@@ -68,7 +68,7 @@ func main() {
 func tickModules(config Config, modules *Modules) {
 	var start = time.Now()
 
-	allMetrics := []Metric{}
+	allMetrics := []*ModuleMetrics{}
 
 	// send metric requests to the input modules in a non blocking manner
 	for i, c := range modules.InputChannels {
@@ -85,7 +85,7 @@ func tickModules(config Config, modules *Modules) {
 	for collectMetrics {
 		select {
 		case metrics := <-modules.InputResponseChan:
-			allMetrics = append(allMetrics, metrics...)
+			allMetrics = append(allMetrics, metrics)
 		default:
 			collectMetrics = false
 		}

--- a/memory_linux.go
+++ b/memory_linux.go
@@ -6,48 +6,46 @@ import (
 	"io/ioutil"
 	"strconv"
 	"strings"
-	"time"
 )
 
-func (m *MemoryInputModule) GetMetrics() ([]Metric, error) {
+func (m *MemoryInputModule) GetMetrics() (*ModuleMetrics, error) {
 	metrics := make([]Metric, 0, 50)
-	now := time.Now()
 
 	meminfo, err := ParseMeminfo("/proc/meminfo")
 	if err != nil {
 		return nil, err
 	}
 
-	metrics = append(metrics, Metric{module: m.Name(), name: "Total", value: meminfo["MemTotal"], timestamp: now})
-	metrics = append(metrics, Metric{module: m.Name(), name: "Free", value: meminfo["MemFree"], timestamp: now})
+	metrics = append(metrics, NewMetric("Total", meminfo["MemTotal"]))
+	metrics = append(metrics, NewMetric("Free", meminfo["MemFree"]))
 
 	used := meminfo["MemTotal"] - (meminfo["MemFree"])
 
-	metrics = append(metrics, Metric{module: m.Name(), name: "Used", value: used, timestamp: now})
-	metrics = append(metrics, Metric{module: m.Name(), name: "Cached", value: meminfo["Cached"], timestamp: now})
-	metrics = append(metrics, Metric{module: m.Name(), name: "Buffer", value: meminfo["Buffers"], timestamp: now})
+	metrics = append(metrics, NewMetric("Used", used))
+	metrics = append(metrics, NewMetric("Cached", meminfo["Cached"]))
+	metrics = append(metrics, NewMetric("Buffer", meminfo["Buffers"]))
 
 	bcTotal := meminfo["Cached"] + meminfo["Buffers"]
 	bcUsed := used - bcTotal
 	bcFree := meminfo["MemFree"] + bcTotal
 
-	metrics = append(metrics, Metric{module: m.Name(), name: "BufferCacheTotal", value: bcTotal, timestamp: now})
-	metrics = append(metrics, Metric{module: m.Name(), name: "BufferCacheUser", value: bcUsed, timestamp: now})
-	metrics = append(metrics, Metric{module: m.Name(), name: "BufferCacheFree", value: bcFree, timestamp: now})
+	metrics = append(metrics, NewMetric("BufferCacheTotal", bcTotal))
+	metrics = append(metrics, NewMetric("BufferCacheUser", bcUsed))
+	metrics = append(metrics, NewMetric("BufferCacheFree", bcFree))
 
-	metrics = append(metrics, Metric{module: m.Name(), name: "SwapTotal", value: meminfo["SwapTotal"], timestamp: now})
-	metrics = append(metrics, Metric{module: m.Name(), name: "SwapFree", value: meminfo["SwapFree"], timestamp: now})
+	metrics = append(metrics, NewMetric("SwapTotal", meminfo["SwapTotal"]))
+	metrics = append(metrics, NewMetric("SwapFree", meminfo["SwapFree"]))
 
-	metrics = append(metrics, Metric{module: m.Name(), name: "HighTotal", value: meminfo["HighTotal"], timestamp: now})
-	metrics = append(metrics, Metric{module: m.Name(), name: "HighFree", value: meminfo["HighFree"], timestamp: now})
+	metrics = append(metrics, NewMetric("HighTotal", meminfo["HighTotal"]))
+	metrics = append(metrics, NewMetric("HighFree", meminfo["HighFree"]))
 
-	metrics = append(metrics, Metric{module: m.Name(), name: "LowTotal", value: meminfo["LowTotal"], timestamp: now})
-	metrics = append(metrics, Metric{module: m.Name(), name: "LowFree", value: meminfo["LowFree"], timestamp: now})
+	metrics = append(metrics, NewMetric("LowTotal", meminfo["LowTotal"]))
+	metrics = append(metrics, NewMetric("LowFree", meminfo["LowFree"]))
 
-	metrics = append(metrics, Metric{module: m.Name(), name: "SlabReclaimable", value: meminfo["SReclaimable"], timestamp: now})
-	metrics = append(metrics, Metric{module: m.Name(), name: "SlabUnreclaimable", value: meminfo["SUnreclaim"], timestamp: now})
+	metrics = append(metrics, NewMetric("SlabReclaimable", meminfo["SReclaimable"]))
+	metrics = append(metrics, NewMetric("SlabUnreclaimable", meminfo["SUnreclaim"]))
 
-	return metrics, nil
+	return &ModuleMetrics{Module: m.Name(), Metrics: metrics}, nil
 }
 
 func ParseMeminfo(path string) (map[string]float64, error) {

--- a/metric.go
+++ b/metric.go
@@ -4,10 +4,23 @@ import (
 	"time"
 )
 
+type ModuleMetrics struct {
+	Module  string
+	Metrics []Metric
+}
+
 // Metric stores all data related to a system metric
 type Metric struct {
-	module    string
-	name      string
-	value     float64
-	timestamp time.Time
+	Name      string
+	Value     float64
+	Timestamp time.Time
+}
+
+// NewMetric creates a new Metric structure and automatically sets the timestamp
+func NewMetric(name string, value float64) Metric {
+	m := Metric{}
+	m.Name = name
+	m.Value = value
+	m.Timestamp = time.Now()
+	return m
 }


### PR DESCRIPTION
The goal is to simplify how we create Metric structures.  Previously we were required to set the module name in each struct.  Now we have a higher level structure which includes the module name and the list of associated metrics.  There is now also a NewMetric function, which will create a Metric structure.  It automatically sets the timestamp on the metric.  This does result in more calls to time.Now(), but does make the code more readable.
